### PR TITLE
Skip slow node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     - git clone https://github.com/google/snappy
     - ( cd snappy && sh ./autogen.sh && ./configure && make -j2 && sudo make install && sudo ldconfig )
     - sudo apt-get install zlib1g-dev
-    - git clone https://github.com/bluebore/sofa-pbrpc ./thirdparty/sofa-pbrpc
+    - git clone https://github.com/baidu/sofa-pbrpc ./thirdparty/sofa-pbrpc
     - ( cd thirdparty/sofa-pbrpc && make -j4 && make install);
     - wget https://github.com/gflags/gflags/archive/v2.1.2.tar.gz
     - tar xf v2.1.2.tar.gz

--- a/src/client/bfs_client.cc
+++ b/src/client/bfs_client.cc
@@ -90,7 +90,6 @@ int BfsCat(bfs::FS* fs, int argc, char* argv[]) {
             bytes += len;
             write(1, buf, len);
         }
-        delete file;
     }
     return len;
 }
@@ -128,7 +127,6 @@ int BfsGet(bfs::FS* fs, int argc, char* argv[]) {
         fwrite(buf, len, 1, fp);
     }
     printf("Read %ld bytes from %s\n", bytes, argv[1]);
-    delete file;
     fclose(fp);
     return len;
 }
@@ -168,7 +166,6 @@ int BfsPut(bfs::FS* fs, int argc, char* argv[]) {
         fprintf(stderr, "close fail: %s\n", argv[3]);
         ret = 1;
     }
-    //delete file;
     fclose(fp);
     printf("Put file to bfs %s %ld bytes\n", argv[3], len);
     return ret;

--- a/src/client/bfs_client.cc
+++ b/src/client/bfs_client.cc
@@ -168,7 +168,7 @@ int BfsPut(bfs::FS* fs, int argc, char* argv[]) {
         fprintf(stderr, "close fail: %s\n", argv[3]);
         ret = 1;
     }
-    delete file;
+    //delete file;
     fclose(fp);
     printf("Put file to bfs %s %ld bytes\n", argv[3], len);
     return ret;

--- a/src/common/logging.cc
+++ b/src/common/logging.cc
@@ -24,9 +24,9 @@
 
 namespace common {
 
-int g_log_level = INFO;
-FILE* g_log_file = stdout;
-FILE* g_warning_file = NULL;
+int g_log_level;
+FILE* g_log_file;
+FILE* g_warning_file;
 
 void SetLogLevel(int level) {
     g_log_level = level;
@@ -36,6 +36,9 @@ class AsyncLogger {
 public:
     AsyncLogger()
       : jobs_(&mu_), done_(&mu_), stopped_(false) {
+        g_log_level = INFO;
+        g_log_file = stdout;
+        g_warning_file = NULL;
         thread_.Start(boost::bind(&AsyncLogger::AsyncWriter, this));
     }
     ~AsyncLogger() {
@@ -97,8 +100,6 @@ private:
     std::queue<std::pair<int, std::string*> > buffer_queue_;
 };
 
-AsyncLogger g_logger;
-
 bool SetWarningFile(const char* path, bool append) {
     const char* mode = append ? "ab" : "wb";
     FILE* fp = fopen(path, mode);
@@ -127,6 +128,7 @@ bool SetLogFile(const char* path, bool append) {
 }
 
 void Logv(int log_level, const char* format, va_list ap) {
+    static AsyncLogger g_logger;
     const uint64_t thread_id = syscall(__NR_gettid);
 
     // We try twice: the first time with a fixed-size stack allocated buffer,

--- a/src/common/sliding_window.h
+++ b/src/common/sliding_window.h
@@ -103,7 +103,7 @@ private:
     int32_t base_offset_;
     int32_t ready_;
     bool notifying_;
-    Mutex mu_;
+    mutable Mutex mu_;
 };
 
 } // namespace common

--- a/src/common/sliding_window.h
+++ b/src/common/sliding_window.h
@@ -36,6 +36,9 @@ public:
     int32_t Size() const {
         return item_count_;
     }
+    int32_t GetBaseOffset() const {
+        return base_offset_;
+    }
     void GetFragments(std::vector<std::pair<int32_t, Item> >* fragments) {
         MutexLock lock(&mu_);
         for (int i = 0; i < size_; i++) {

--- a/src/common/sliding_window.h
+++ b/src/common/sliding_window.h
@@ -65,6 +65,7 @@ public:
         notifying_ = false;
     }
     int32_t UpBound() const {
+        MutexLock lock(&mu_);
         return base_offset_ + size_ - 1;
     }
     /// Add a new item to slinding window.

--- a/src/common/thread_pool.h
+++ b/src/common/thread_pool.h
@@ -14,6 +14,7 @@
 #include <boost/function.hpp>
 #include "mutex.h"
 #include "timer.h"
+#include "logging.h"
 
 namespace common {
 
@@ -40,6 +41,11 @@ public:
         if (tids_.size()) {
             return false;
         }
+        /// It's a ticky here. Call LOG just to make sure g_logger
+        /// is uninitialized before thread pool, so g_logger is sure
+        /// to be deconstructed after thread pool. So when destroy
+        /// this thread pool, threads can safely write on-going logs out.
+        LOG(INFO, "Init thread pool");
         stop_ = false;
         for (int i = 0; i < threads_num_; i++) {
             pthread_t tid;

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -784,7 +784,12 @@ void NameServerImpl::AddBlock(::google::protobuf::RpcController* controller,
         assert(0);
     }
     /// replica num
-    int replica_num = file_info.replicas();
+    int replica_num;
+    if (request->has_replica_num()) {
+        replica_num = request->replica_num();
+    } else {
+        replica_num = file_info.replicas();
+    }
     /// check lease for write
     std::vector<std::pair<int32_t, std::string> > chains;
     if (_chunkserver_manager->GetChunkServerChains(replica_num, &chains)) {

--- a/src/proto/nameserver.proto
+++ b/src/proto/nameserver.proto
@@ -70,6 +70,7 @@ message RenameResponse {
 message AddBlockRequest {
     required int64 sequence_id = 1;
     required string file_name = 2;
+    optional int32 replica_num = 3;
 }
 message AddBlockResponse {
     required int64 sequence_id = 1;

--- a/src/sdk/bfs.cc
+++ b/src/sdk/bfs.cc
@@ -979,7 +979,9 @@ bool BfsFileImpl::Sync() {
         StartWrite(_write_buf);
     }
     int wait_time = 0;
-    while (_back_writing) {
+    while ((FLAGS_sdk_write_mode == "chains" && _back_writing) ||
+            (FLAGS_sdk_write_mode == "fan-out" &&
+            BackgroundDoneChunkserverNum() < FLAGS_default_replica_num)) {
         bool finish = _sync_signal.TimeWait(1000, "Sync wait");
         if (++wait_time >= 30 && (wait_time % 10 == 0)) {
             LOG(WARNING, "Sync timeout %d s, %s _back_writing= %d, finish= %d",

--- a/src/sdk/bfs.cc
+++ b/src/sdk/bfs.cc
@@ -874,7 +874,6 @@ void BfsFileImpl::WriteChunkCallback(const WriteBlockRequest* request,
                                      int retry_times,
                                      WriteBuffer* buffer,
                                      std::string cs_addr) {
-    /*
     if (_closed || _bg_error) {
         LOG(INFO, "BackgroundWrite been omitted bid:%ld, seq:%d",
                     " offset:%ld, len:%d, _back_writing:%d",
@@ -886,7 +885,6 @@ void BfsFileImpl::WriteChunkCallback(const WriteBlockRequest* request,
         delete response;
         return;
     }
-    */
     if (failed || response->status() != 0) {
         if (sofa::pbrpc::RPC_ERROR_SEND_BUFFER_FULL != error
                 && response->status() != 500) {
@@ -1052,7 +1050,6 @@ bool FS::OpenFileSystem(const char* nameserver, FS** fs) {
         return false;
     }
     *fs = impl;
-    g_thread_pool.Start();
     return true;
 }
 

--- a/tera/bfs_wrapper.cc
+++ b/tera/bfs_wrapper.cc
@@ -81,7 +81,6 @@ int32_t BfsFile::CloseFile() {
     LOG(INFO, "CloseFile(%s)", _name.c_str());
     common::timer::AutoTimer ac(1, "CloseFile", _name.c_str());
     bool ret = _file->Close();
-    delete _file;
     _file = NULL;
     if (!ret) {
         LOG(INFO, "CloseFile(%s) fail", _name.c_str());


### PR DESCRIPTION
暂时还有一个大问题，就是当关闭文件时，虽然可以跳过慢节点，但是可能还有后台线程在写慢节点，这时候如果delete文件描述符就悲剧了。
另外，对于close之后，多余副本的回收，还没有做，感觉这个要等第一个问题解决之后再考虑。