### PR TITLE
Fix memory leak

### DIFF
--- a/src/sdk/bfs.cc
+++ b/src/sdk/bfs.cc
@@ -603,6 +603,7 @@ int32_t BfsFileImpl::Pread(char* buf, int32_t read_len, int64_t offset, bool rea
             fs_->rpc_client_->GetStub(cs_addr, &chunk_server);
             {
                 MutexLock lock(&mu_, "Pread change chunkserver_", 1000);
+                delete chunkserver_;
                 chunkserver_ = chunk_server;
             }
         } else {


### PR DESCRIPTION
这么改也有问题：
1)要是同一个文件描述符，只允许单线程读，那么其实连锁都不用。
2)要是同一个文件描述符，允许多个线程读，那么delete也不行。只能用智能指针？

SDK中好像还有其它类似的地方。