### PR TITLE
Fix log & stat

### DIFF
--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -138,7 +138,7 @@ void ChunkServerImpl::Register() {
     request.set_disk_quota(block_manager_->DiskQuota());
     request.set_namespace_version(block_manager_->NameSpaceVersion());
 
-    LOG(INFO, "Send Register request with version %ld", request.namespace_version());
+    LOG(INFO, "Send Register request with version V%ld ", request.namespace_version());
     RegisterResponse response;
     if (!rpc_client_->SendRequest(nameserver_, &NameServer_Stub::Register,
             &request, &response, 20, 3)) {
@@ -158,7 +158,7 @@ void ChunkServerImpl::Register() {
             /// abort
             LOG(FATAL, "Name space verion FLAGS_chunkserver_auto_clean == false");
         }
-        LOG(INFO, "Use new namespace version: %ld, clean local data", new_version);
+        LOG(INFO, "Use new namespace version: V%ld, clean local data", new_version);
         // Clean
         if (!block_manager_->RemoveAllBlocks()) {
             LOG(FATAL, "Remove local blocks fail");
@@ -171,7 +171,7 @@ void ChunkServerImpl::Register() {
     }
     assert (response.chunkserver_id() != -1);
     chunkserver_id_ = response.chunkserver_id();
-    LOG(INFO, "Connect to nameserver version= %ld, cs_id = %d",
+    LOG(INFO, "Connect to nameserver version= V%ld, cs_id = C%d ",
         block_manager_->NameSpaceVersion(), chunkserver_id_);
 
     work_thread_pool_->DelayTask(1, boost::bind(&ChunkServerImpl::SendBlockReport, this));
@@ -305,11 +305,11 @@ bool ChunkServerImpl::ReportFinish(Block* block) {
     BlockReceivedResponse response;
     if (!rpc_client_->SendRequest(nameserver_, &NameServer_Stub::BlockReceived,
             &request, &response, 20, 3)) {
-        LOG(WARNING, "Reprot finish fail: %ld\n", block->Id());
+        LOG(WARNING, "Reprot finish fail: #%ld ", block->Id());
         return false;
     }
 
-    LOG(INFO, "Report finish to nameserver done, block_id: %ld\n", block->Id());
+    LOG(INFO, "Report finish to nameserver done, block_id: #%ld\n", block->Id());
     return true;
 }
 

--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -138,7 +138,7 @@ void ChunkServerImpl::Register() {
     request.set_disk_quota(block_manager_->DiskQuota());
     request.set_namespace_version(block_manager_->NameSpaceVersion());
 
-    LOG(INFO, "Send Register request with version V%ld ", request.namespace_version());
+    LOG(INFO, "Send Register request with version %ld ", request.namespace_version());
     RegisterResponse response;
     if (!rpc_client_->SendRequest(nameserver_, &NameServer_Stub::Register,
             &request, &response, 20, 3)) {
@@ -158,7 +158,7 @@ void ChunkServerImpl::Register() {
             /// abort
             LOG(FATAL, "Name space verion FLAGS_chunkserver_auto_clean == false");
         }
-        LOG(INFO, "Use new namespace version: V%ld, clean local data", new_version);
+        LOG(INFO, "Use new namespace version: %ld, clean local data", new_version);
         // Clean
         if (!block_manager_->RemoveAllBlocks()) {
             LOG(FATAL, "Remove local blocks fail");
@@ -171,7 +171,7 @@ void ChunkServerImpl::Register() {
     }
     assert (response.chunkserver_id() != -1);
     chunkserver_id_ = response.chunkserver_id();
-    LOG(INFO, "Connect to nameserver version= V%ld, cs_id = C%d ",
+    LOG(INFO, "Connect to nameserver version= %ld, cs_id = C%d ",
         block_manager_->NameSpaceVersion(), chunkserver_id_);
 
     work_thread_pool_->DelayTask(1, boost::bind(&ChunkServerImpl::SendBlockReport, this));

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -451,18 +451,22 @@ void NameServerImpl::Stat(::google::protobuf::RpcController* controller,
     if (namespace_->GetFileInfo(path, &info)) {
         FileInfo* out_info = response->mutable_file_info();
         out_info->CopyFrom(info);
-        int64_t file_size = 0;
-        for (int i = 0; i < out_info->blocks_size(); i++) {
-            int64_t block_id = out_info->blocks(i);
-            NSBlock nsblock;
-            if (!block_mapping_->GetBlock(block_id, &nsblock)) {
-                continue;
+        out_info->set_size(info.size());
+        //maybe haven't been written info meta
+        if (!out_info->size()) {
+            int64_t file_size = 0;
+            for (int i = 0; i < out_info->blocks_size(); i++) {
+                int64_t block_id = out_info->blocks(i);
+                NSBlock nsblock;
+                if (!block_mapping_->GetBlock(block_id, &nsblock)) {
+                    continue;
+                }
+                file_size += nsblock.block_size;
             }
-            file_size += nsblock.block_size;
+            out_info->set_size(file_size);
         }
-        out_info->set_size(file_size);
         response->set_status(kOK);
-        LOG(INFO, "Stat: %s return: %ld", path.c_str(), file_size);
+        LOG(INFO, "Stat: %s return: %ld", path.c_str(), out_info->size());
     } else {
         LOG(INFO, "Stat: %s return: not found", path.c_str());
         response->set_status(kNotFound);

--- a/src/nameserver/nameserver_impl.cc
+++ b/src/nameserver/nameserver_impl.cc
@@ -451,7 +451,6 @@ void NameServerImpl::Stat(::google::protobuf::RpcController* controller,
     if (namespace_->GetFileInfo(path, &info)) {
         FileInfo* out_info = response->mutable_file_info();
         out_info->CopyFrom(info);
-        out_info->set_size(info.size());
         //maybe haven't been written info meta
         if (!out_info->size()) {
             int64_t file_size = 0;

--- a/src/nameserver/namespace.cc
+++ b/src/nameserver/namespace.cc
@@ -45,7 +45,7 @@ NameSpace::NameSpace(): last_entry_id_(1) {
             LOG(FATAL, "Bad namespace version len= %lu.", version_str.size());
         }
         version_ = *(reinterpret_cast<int64_t*>(&version_str[0]));
-        LOG(INFO, "Load namespace version: %ld", version_);
+        LOG(INFO, "Load namespace version: V%ld ", version_);
     } else {
         version_ = common::timer::get_micros();
         version_str.resize(8);
@@ -54,7 +54,7 @@ NameSpace::NameSpace(): last_entry_id_(1) {
         if (!s.ok()) {
             LOG(FATAL, "Write namespace version to db fail: %s", s.ToString().c_str());
         }
-        LOG(INFO, "Create new namespace version: %ld", version_);
+        LOG(INFO, "Create new namespace version: V%ld ", version_);
     }
     SetupRoot();
 }
@@ -142,10 +142,10 @@ bool NameSpace::LookUp(int64_t parent_id, const std::string& name, FileInfo* inf
     std::string key_str;
     EncodingStoreKey(parent_id, name, &key_str);
     if (!GetFromStore(key_str, info)) {
-        LOG(INFO, "LookUp %ld %s return false", parent_id, name.c_str());
+        LOG(INFO, "LookUp E%ld %s return false", parent_id, name.c_str());
         return false;
     }
-    LOG(DEBUG, "LookUp %ld %s return true", parent_id, name.c_str());
+    LOG(DEBUG, "LookUp E%ld %s return true", parent_id, name.c_str());
     return true;
 }
 

--- a/src/nameserver/namespace.cc
+++ b/src/nameserver/namespace.cc
@@ -45,7 +45,7 @@ NameSpace::NameSpace(): last_entry_id_(1) {
             LOG(FATAL, "Bad namespace version len= %lu.", version_str.size());
         }
         version_ = *(reinterpret_cast<int64_t*>(&version_str[0]));
-        LOG(INFO, "Load namespace version: V%ld ", version_);
+        LOG(INFO, "Load namespace version: %ld ", version_);
     } else {
         version_ = common::timer::get_micros();
         version_str.resize(8);
@@ -54,7 +54,7 @@ NameSpace::NameSpace(): last_entry_id_(1) {
         if (!s.ok()) {
             LOG(FATAL, "Write namespace version to db fail: %s", s.ToString().c_str());
         }
-        LOG(INFO, "Create new namespace version: V%ld ", version_);
+        LOG(INFO, "Create new namespace version: %ld ", version_);
     }
     SetupRoot();
 }

--- a/src/proto/file.proto
+++ b/src/proto/file.proto
@@ -8,7 +8,7 @@ message FileInfo {
     repeated int64 blocks = 4;
     optional uint32 ctime = 5;
     optional string name = 6;
-    optional int64 size = 7 [default = 0];
+    optional int64 size = 7;
     optional int32 replicas = 8;
     optional int64 parent_entry_id = 9;
     optional int32 owner = 10;

--- a/src/proto/file.proto
+++ b/src/proto/file.proto
@@ -8,7 +8,7 @@ message FileInfo {
     repeated int64 blocks = 4;
     optional uint32 ctime = 5;
     optional string name = 6;
-    optional int64 size = 7;
+    optional int64 size = 7 [default = 0];
     optional int32 replicas = 8;
     optional int64 parent_entry_id = 9;
     optional int32 owner = 10;


### PR DESCRIPTION
另外，在高版本的副本挂掉，只剩低版本的副本时，是否有必要将block的大小及文件大小等元数据更新到namespace？不更新的话，若高版本的副本永远挂掉，则namespace中的信息便会一直与实际信息不一致