### PR TITLE
Allow return pulling blocks

### DIFF
--- a/src/nameserver/block_mapping.cc
+++ b/src/nameserver/block_mapping.cc
@@ -63,7 +63,8 @@ bool BlockMapping::GetLocatedBlock(int64_t id, std::vector<int32_t>* replica ,in
     }
     replica->assign(block->replica.begin(), block->replica.end());
     if (block->recover_stat == kBlockWriting
-        || block->recover_stat == kIncomplete) {
+        || block->recover_stat == kIncomplete
+        || block->recover_stat == kCheck) {
         LOG(DEBUG, "GetLocatedBlock return writing block #%ld ", id);
         replica->insert(replica->end(),
                         block->incomplete_replica.begin(),


### PR DESCRIPTION
允许GetLocatedBlocks返回正在pulling的block
这样，在部分cs连不上时，给sdk多一些可能。。。 