### PR TITLE
Fix bug in sdk write flow control

### DIFF
--- a/src/sdk/bfs.cc
+++ b/src/sdk/bfs.cc
@@ -867,7 +867,7 @@ void BfsFileImpl::BackgroundWrite() {
         for (size_t i = 0; i < chunkservers_.size(); i++) {
             std::string cs_addr = block_for_write_->chains(i).address();
             bool delay = false;
-            if (!(write_windows_[cs_addr]->UpBound() > write_queue_.top()->Sequence())) {
+            if (write_windows_[cs_addr]->UpBound() < buffer->Sequence()) {
                 delay = true;
             }
             {


### PR DESCRIPTION
此时在锁外，用write_queue_.top()是不安全的