### PR TITLE
Use std::list instead of std::vector to store write buffer

### DIFF
--- a/src/chunkserver/data_block.h
+++ b/src/chunkserver/data_block.h
@@ -9,6 +9,7 @@
 
 #include <string>
 #include <vector>
+#include <list>
 
 #include <common/mutex.h>
 #include <common/thread_pool.h>
@@ -97,7 +98,7 @@ private:
     char*       blockbuf_;
     int64_t     buflen_;
     int64_t     bufdatalen_;
-    std::vector<std::pair<const char*,int> > block_buf_list_;
+    std::list<std::pair<const char*,int> > block_buf_list_;
     bool        disk_writing_;
     std::string disk_file_;
     int64_t     disk_file_size_;


### PR DESCRIPTION
vector每次是按原大小的两倍进行扩容的，而且还要复制原来位置的数据，如果写的比较快的话，可能导致内存膨胀的很大，换成list，牺牲一些局部性。