### PR TITLE
Omit sliding window fragments in close

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ yuanyi~
 yuyangquan~  
 leiliyuan~  
 yangce~
+

--- a/README.md
+++ b/README.md
@@ -39,4 +39,3 @@ yuanyi~
 yuyangquan~  
 leiliyuan~  
 yangce~
-

--- a/src/chunkserver/data_block.cc
+++ b/src/chunkserver/data_block.cc
@@ -377,6 +377,7 @@ void Block::DiskWrite() {
                     delete[] frags[i].second.data_;
                 }
             }
+
             delete recv_window_;
             recv_window_ = NULL;
             close_cv_.Signal();

--- a/src/chunkserver/data_block.cc
+++ b/src/chunkserver/data_block.cc
@@ -368,6 +368,7 @@ void Block::DiskWrite() {
                 file_desc_ = -1;
                 g_writing_blocks.Dec();
             }
+            assert(recv_window_);
             if (recv_window_->Size()) {
                 LOG(INFO, "#%ld recv_window fragments: %d\n",
                         meta_.block_id, recv_window_->Size());

--- a/src/chunkserver/data_block.cc
+++ b/src/chunkserver/data_block.cc
@@ -368,7 +368,6 @@ void Block::DiskWrite() {
                 file_desc_ = -1;
                 g_writing_blocks.Dec();
             }
-            /*
             if (recv_window_->Size()) {
                 LOG(INFO, "#%ld recv_window fragments: %d\n",
                         meta_.block_id, recv_window_->Size());
@@ -378,10 +377,8 @@ void Block::DiskWrite() {
                     delete[] frags[i].second.data_;
                 }
             }
-
             delete recv_window_;
             recv_window_ = NULL;
-            */
             close_cv_.Signal();
         }
     }

--- a/src/chunkserver/data_block.cc
+++ b/src/chunkserver/data_block.cc
@@ -328,8 +328,8 @@ void Block::DiskWrite() {
             this->DecRef();
             return;
         }
+        disk_writing_ = true;
         if (!deleted_) {
-            disk_writing_ = true;
             while (!block_buf_list_.empty() && !deleted_) {
                 if (!OpenForWrite()) assert(0);
                 const char* buf = block_buf_list_[0].first;
@@ -357,7 +357,6 @@ void Block::DiskWrite() {
                 g_buffers_delete.Inc();
                 disk_file_size_ += len;
             }
-            disk_writing_ = false;
         }
         if (finished_ || deleted_) {
             assert (deleted_ || block_buf_list_.empty());
@@ -382,6 +381,7 @@ void Block::DiskWrite() {
             recv_window_ = NULL;
             close_cv_.Signal();
         }
+        disk_writing_ = false;
     }
     this->DecRef();
 }

--- a/src/chunkserver/data_block.cc
+++ b/src/chunkserver/data_block.cc
@@ -367,8 +367,7 @@ void Block::DiskWrite() {
                 file_desc_ = -1;
                 g_writing_blocks.Dec();
             }
-            assert(recv_window_);
-            if (recv_window_->Size()) {
+            if (recv_window_ && recv_window_->Size()) {
                 LOG(INFO, "#%ld recv_window fragments: %d\n",
                         meta_.block_id, recv_window_->Size());
                 std::vector<std::pair<int32_t,Buffer> > frags;

--- a/src/chunkserver/data_block.cc
+++ b/src/chunkserver/data_block.cc
@@ -368,6 +368,7 @@ void Block::DiskWrite() {
                 file_desc_ = -1;
                 g_writing_blocks.Dec();
             }
+            /*
             if (recv_window_->Size()) {
                 LOG(INFO, "#%ld recv_window fragments: %d\n",
                         meta_.block_id, recv_window_->Size());
@@ -380,6 +381,7 @@ void Block::DiskWrite() {
 
             delete recv_window_;
             recv_window_ = NULL;
+            */
             close_cv_.Signal();
         }
     }


### PR DESCRIPTION
close时释放滑动窗口中的碎片