### PR TITLE
Store block path

### DIFF
--- a/src/chunkserver/block_manager.cc
+++ b/src/chunkserver/block_manager.cc
@@ -374,11 +374,6 @@ bool BlockManager::RemoveBlock(int64_t block_id) {
             block_id, file_path.c_str());
     }
 
-    //char dir_name[5];
-    //snprintf(dir_name, sizeof(dir_name), "/%03ld", block_id % 1000);
-    // Rmdir, ignore error when not empty.
-    // rmdir((GetStorePath(block_id) + dir_name).c_str());
-    // rmdir((block->meta_.store_path() + dir_name).c_str());
     if (meta_removed) {
         MutexLock lock(&mu_, "BlockManager::RemoveBlock erase", 1000);
         block_map_.erase(block_id);

--- a/src/chunkserver/block_manager.cc
+++ b/src/chunkserver/block_manager.cc
@@ -159,6 +159,11 @@ bool BlockManager::LoadStorage() {
             remove(file_path.c_str());
             continue;
         } else {
+            if (std::find(store_path_list_.begin(), store_path_list_.end(), meta.store_path())
+                    == store_path_list_.end()) {
+                LOG(WARNING, "Store path of %s not in current store configuration, ignore it", file_path.c_str());
+                continue;
+            }
             struct stat st;
             if (stat(file_path.c_str(), &st) ||
                 st.st_size != meta.block_size() ||

--- a/src/chunkserver/block_manager.cc
+++ b/src/chunkserver/block_manager.cc
@@ -225,6 +225,11 @@ bool BlockManager::ListBlocks(std::vector<BlockMeta>* blocks, int64_t offset, in
         }
         BlockMeta meta;
         meta.ParseFromArray(it->value().data(), it->value().size());
+        //skip blocks not in current configuration
+        if (find(store_path_list_.begin(), store_path_list_.end(), meta.store_path())
+                  == store_path_list_.end()) {
+            continue;
+        }
         assert(meta.block_id() == block_id);
         blocks->push_back(meta);
         // LOG(DEBUG, "List block %ld", block_id);

--- a/src/chunkserver/block_manager.cc
+++ b/src/chunkserver/block_manager.cc
@@ -161,7 +161,8 @@ bool BlockManager::LoadStorage() {
         } else {
             if (std::find(store_path_list_.begin(), store_path_list_.end(), meta.store_path())
                     == store_path_list_.end()) {
-                LOG(WARNING, "Store path of %s not in current store configuration, ignore it", file_path.c_str());
+                LOG(WARNING, "Block #%ld store path %s not in current store configuration, ignore it",
+                        file_path.c_str());
                 continue;
             }
             struct stat st;

--- a/src/chunkserver/block_manager.cc
+++ b/src/chunkserver/block_manager.cc
@@ -149,33 +149,32 @@ bool BlockManager::LoadStorage() {
             return false;
         }
         BlockMeta meta;
-        assert(it->value().size() == sizeof(meta));
-        memcpy(&meta, it->value().data(), sizeof(meta));
-        assert(meta.block_id == block_id);
-        std::string file_path = GetStorePath(block_id) + Block::BuildFilePath(block_id);
-        if (meta.version < 0) {
+        meta.ParseFromArray(it->value().data(), it->value().size());
+        assert(meta.block_id() == block_id);
+        std::string file_path = meta.store_path() + Block::BuildFilePath(block_id);
+        if (meta.version() < 0) {
             LOG(INFO, "Incomplete block #%ld V%ld %ld, drop it",
-                block_id, meta.version, meta.block_size);
+                block_id, meta.version(), meta.block_size());
             metadb_->Delete(leveldb::WriteOptions(), it->key());
             remove(file_path.c_str());
             continue;
         } else {
             struct stat st;
             if (stat(file_path.c_str(), &st) ||
-                st.st_size != meta.block_size ||
+                st.st_size != meta.block_size() ||
                 access(file_path.c_str(), R_OK)) {
                 LOG(WARNING, "Corrupted block #%ld V%ld size %ld path %s can't access: %s'",
-                    block_id, meta.version, meta.block_size, file_path.c_str(),
+                    block_id, meta.version(), meta.block_size(), file_path.c_str(),
                     strerror(errno));
                 metadb_->Delete(leveldb::WriteOptions(), it->key());
                 remove(file_path.c_str());
                 continue;
             } else {
                 LOG(DEBUG, "Load #%ld V%ld size %ld path %s",
-                    block_id, meta.version, meta.block_size, file_path.c_str());
+                    block_id, meta.version(), meta.block_size(), file_path.c_str());
             }
         }
-        Block* block = new Block(meta, GetStorePath(block_id), thread_pool_, file_cache_);
+        Block* block = new Block(meta, thread_pool_, file_cache_);
         block->AddRef();
         block_map_[block_id] = block;
         block_num ++;
@@ -220,9 +219,8 @@ bool BlockManager::ListBlocks(std::vector<BlockMeta>* blocks, int64_t offset, in
             return false;
         }
         BlockMeta meta;
-        assert(it->value().size() == sizeof(meta));
-        memcpy(&meta, it->value().data(), sizeof(meta));
-        assert(meta.block_id == block_id);
+        meta.ParseFromArray(it->value().data(), it->value().size());
+        assert(meta.block_id() == block_id);
         blocks->push_back(meta);
         // LOG(DEBUG, "List block %ld", block_id);
         if (--num <= 0) {
@@ -235,9 +233,9 @@ bool BlockManager::ListBlocks(std::vector<BlockMeta>* blocks, int64_t offset, in
 
 Block* BlockManager::CreateBlock(int64_t block_id, int64_t* sync_time, StatusCode* status) {
     BlockMeta meta;
-    meta.block_id = block_id;
-    Block* block = new Block(meta, GetStorePath(block_id), thread_pool_, file_cache_);
-    // for block_map
+    meta.set_block_id(block_id);
+    meta.set_store_path(GetStorePath(block_id));
+    Block* block = new Block(meta, thread_pool_, file_cache_);
     MutexLock lock(&mu_, "BlockManger::AddBlock", 1000);
     BlockMap::iterator it = block_map_.find(block_id);
     if (it != block_map_.end()) {
@@ -249,6 +247,7 @@ Block* BlockManager::CreateBlock(int64_t block_id, int64_t* sync_time, StatusCod
         *status = kBlockExist;
         return it->second;
     }
+    // for block_map
     block->AddRef();
     block_map_[block_id] = block;
     // Unlock for write meta & sync
@@ -288,12 +287,13 @@ std::string BlockManager::BlockId2Str(int64_t block_id) {
     return std::string(idstr);
 }
 bool BlockManager::SyncBlockMeta(const BlockMeta& meta, int64_t* sync_time) {
-    std::string idstr = BlockId2Str(meta.block_id);
+    std::string idstr = BlockId2Str(meta.block_id());
     leveldb::WriteOptions options;
     // options.sync = true;
     int64_t time_start = common::timer::get_micros();
-    leveldb::Status s = metadb_->Put(options, idstr,
-        leveldb::Slice(reinterpret_cast<const char*>(&meta),sizeof(meta)));
+    std::string meta_buf;
+    meta.SerializeToString(&meta_buf);
+    leveldb::Status s = metadb_->Put(options, idstr, meta_buf);
     int64_t time_use = common::timer::get_micros() - time_start;
     if (sync_time) *sync_time = time_use;
     if (!s.ok()) {
@@ -347,10 +347,11 @@ bool BlockManager::RemoveBlock(int64_t block_id) {
             block_id, file_path.c_str());
     }
 
-    char dir_name[5];
-    snprintf(dir_name, sizeof(dir_name), "/%03ld", block_id % 1000);
+    //char dir_name[5];
+    //snprintf(dir_name, sizeof(dir_name), "/%03ld", block_id % 1000);
     // Rmdir, ignore error when not empty.
     // rmdir((GetStorePath(block_id) + dir_name).c_str());
+    // rmdir((block->meta_.store_path() + dir_name).c_str());
     if (meta_removed) {
         MutexLock lock(&mu_, "BlockManager::RemoveBlock erase", 1000);
         block_map_.erase(block_id);

--- a/src/chunkserver/chunkserver_impl.cc
+++ b/src/chunkserver/chunkserver_impl.cc
@@ -235,16 +235,16 @@ void ChunkServerImpl::SendBlockReport() {
     int64_t blocks_num = blocks.size();
     for (int64_t i = 0; i < blocks_num; i++) {
         ReportBlockInfo* info = request.add_blocks();
-        info->set_block_id(blocks[i].block_id);
-        info->set_block_size(blocks[i].block_size);
-        info->set_version(blocks[i].version);
+        info->set_block_id(blocks[i].block_id());
+        info->set_block_size(blocks[i].block_size());
+        info->set_version(blocks[i].version());
     }
 
     if (blocks_num < FLAGS_blockreport_size) {
         last_report_blockid_ = -1;
     } else {
         if (blocks_num) {
-            last_report_blockid_ = blocks[blocks_num - 1].block_id;
+            last_report_blockid_ = blocks[blocks_num - 1].block_id();
         }
     }
 
@@ -752,7 +752,7 @@ void ChunkServerImpl::GetBlockInfo(::google::protobuf::RpcController* controller
         status = kNotFound;
         LOG(WARNING, "GetBlockInfo not found: #%ld ", block_id);
     } else {
-        int64_t block_size = block->GetMeta().block_size;
+        int64_t block_size = block->GetMeta().block_size();
         response->set_block_size(block_size);
         status = kOK;
         LOG(INFO, "GetBlockInfo #%ld return: %ld "

--- a/src/chunkserver/data_block.cc
+++ b/src/chunkserver/data_block.cc
@@ -43,18 +43,17 @@ extern common::Counter g_rpc_delay_all;
 extern common::Counter g_rpc_count;
 extern common::Counter g_data_size;
 
-Block::Block(const BlockMeta& meta, const std::string& store_path, ThreadPool* thread_pool,
-      FileCache* file_cache) :
+Block::Block(const BlockMeta& meta, ThreadPool* thread_pool, FileCache* file_cache) :
   thread_pool_(thread_pool), meta_(meta),
   last_seq_(-1), slice_num_(-1), blockbuf_(NULL), buflen_(0),
   bufdatalen_(0), disk_writing_(false),
-  disk_file_size_(meta.block_size), file_desc_(-1), refs_(0),
-  close_cv_(&mu_), is_recover_(false), deleted_(false), file_cache_(file_cache) {
-    assert(meta_.block_id < (1L<<40));
-    g_data_size.Add(meta.block_size);
-    disk_file_ = store_path + BuildFilePath(meta_.block_id);
+  disk_file_size_(meta.block_size()), file_desc_(-1), refs_(0),
+  close_cv_(&mu_), deleted_(false), file_cache_(file_cache) {
+    assert(meta_.block_id() < (1L<<40));
+    g_data_size.Add(meta.block_size());
+    disk_file_ = meta.store_path() + BuildFilePath(meta_.block_id());
     g_blocks.Inc();
-    if (meta_.version >= 0) {
+    if (meta_.version() >= 0) {
         finished_ = true;
         recv_window_ = NULL;
     } else {
@@ -67,7 +66,7 @@ Block::~Block() {
     if (bufdatalen_ > 0) {
         if (!deleted_) {
             LOG(WARNING, "Data lost, %d bytes in #%ld %s",
-                bufdatalen_, meta_.block_id, disk_file_.c_str());
+                bufdatalen_, meta_.block_id(), disk_file_.c_str());
         }
     }
     if (blockbuf_) {
@@ -80,15 +79,15 @@ Block::~Block() {
     bufdatalen_ = 0;
 
     LOG(INFO, "Release #%ld block_buf_list_ size= %lu",
-        meta_.block_id, block_buf_list_.size());
+        meta_.block_id(), block_buf_list_.size());
     for (uint32_t i = 0; i < block_buf_list_.size(); i++) {
         const char* buf = block_buf_list_[i].first;
         int len = block_buf_list_[i].second;
         if (!deleted_) {
             LOG(WARNING, "Data lost, %d bytes in %s, #%ld block_buf_list_",
-                len, disk_file_.c_str(), meta_.block_id);
+                len, disk_file_.c_str(), meta_.block_id());
         } else {
-            LOG(INFO, "Release block_buf_list_ %d for #%ld ", len, meta_.block_id);
+            LOG(INFO, "Release block_buf_list_ %d for #%ld ", len, meta_.block_id());
         }
         delete[] buf;
         g_block_buffers.Dec();
@@ -105,7 +104,7 @@ Block::~Block() {
     if (recv_window_) {
         if (recv_window_->Size()) {
             LOG(INFO, "#%ld recv_window fragments: %d\n",
-                meta_.block_id, recv_window_->Size());
+                meta_.block_id(), recv_window_->Size());
             std::vector<std::pair<int32_t,Buffer> > frags;
             recv_window_->GetFragments(&frags);
             for (uint32_t i = 0; i < frags.size(); i++) {
@@ -114,16 +113,16 @@ Block::~Block() {
         }
         delete recv_window_;
     }
-    LOG(INFO, "Block #%ld deconstruct", meta_.block_id);
+    LOG(INFO, "Block #%ld destruct", meta_.block_id());
     g_blocks.Dec();
-    g_data_size.Sub(meta_.block_size);
+    g_data_size.Sub(meta_.block_size());
 }
 /// Getter
 int64_t Block::Id() const {
-    return meta_.block_id;
+    return meta_.block_id();
 }
 int64_t Block::Size() const {
-    return meta_.block_size;
+    return meta_.block_size();
 }
 std::string Block::GetFilePath() const {
     return disk_file_;
@@ -139,10 +138,10 @@ bool Block::SetDeleted() {
     return (0 == deleted);
 }
 void Block::SetVersion(int64_t version) {
-    meta_.version = std::max(version, meta_.version);
+    meta_.set_version(std::max(version, meta_.version()));
 }
 int Block::GetVersion() {
-    return meta_.version;
+    return meta_.version();
 }
 int32_t Block::GetLastSaq() {
     return last_seq_;
@@ -168,7 +167,7 @@ bool Block::OpenForWrite() {
     mu_.Lock("Block::OpenForWrite");
     if (fd < 0) {
         LOG(WARNING, "Open block #%ld %s fail: %s",
-            meta_.block_id, disk_file_.c_str(), strerror(errno));
+            meta_.block_id(), disk_file_.c_str(), strerror(errno));
         return false;
     }
     g_writing_blocks.Inc();
@@ -189,8 +188,8 @@ bool Block::IsFinished() {
 /// Read operation.
 int64_t Block::Read(char* buf, int64_t len, int64_t offset) {
     MutexLock lock(&mu_, "Block::Read", 1000);
-    if (offset > meta_.block_size) {
-        LOG(INFO, "Wrong offset %ld > %ld", offset, meta_.block_size);
+    if (offset > meta_.block_size()) {
+        LOG(INFO, "Wrong offset %ld > %ld", offset, meta_.block_size());
         return -1;
     } else if (deleted_) {
         return -1;
@@ -242,13 +241,13 @@ bool Block::Write(int32_t seq, int64_t offset, const char* data,
                   int64_t len, int64_t* add_use) {
     if (finished_) {
         LOG(INFO, "Write a finish block #%ld V%ld %ld, seq: %d, offset: %ld",
-            meta_.block_id, meta_.version, meta_.block_size, seq, offset);
+            meta_.block_id(), meta_.version(), meta_.block_size(), seq, offset);
         return false;
     }
-    if (offset < meta_.block_size) {
-        assert (offset + len <= meta_.block_size);
+    if (offset < meta_.block_size()) {
+        assert (offset + len <= meta_.block_size());
         LOG(INFO, "Write #%ld size %ld, seq: %d, wrong offset: %ld",
-            meta_.block_id, meta_.block_size, seq, offset);
+            meta_.block_id(), meta_.block_size(), seq, offset);
         return true;
     }
     char* buf = NULL;
@@ -266,7 +265,7 @@ bool Block::Write(int32_t seq, int64_t offset, const char* data,
         if (ret < 0) {
             LOG(WARNING, "Write block #%ld seq: %d, offset: %ld, block_size: %ld"
                          " out of range %d",
-                meta_.block_id, seq, offset, meta_.block_size, recv_window_->UpBound());
+                meta_.block_id(), seq, offset, meta_.block_size(), recv_window_->UpBound());
             return false;
         }
     }
@@ -295,11 +294,11 @@ bool Block::Close() {
     while (file_desc_ != -1) {
         close_cv_.Wait();
     }
-    if (meta_.version == -1) {
+    if (meta_.version() == -1) {
         SetVersion(last_seq_);
     }
     LOG(INFO, "Block #%ld closed %s V%ld %ld",
-        meta_.block_id, disk_file_.c_str(), meta_.version, meta_.block_size);
+        meta_.block_id(), disk_file_.c_str(), meta_.version(), meta_.block_size());
     return true;
 }
 
@@ -343,7 +342,7 @@ void Block::DiskWrite() {
                     int w = write(file_desc_, buf + wlen, len - wlen);
                     if (w < 0) {
                         LOG(WARNING, "IOError write #%ld %s return %s",
-                            meta_.block_id, disk_file_.c_str(), strerror(errno));
+                            meta_.block_id(), disk_file_.c_str(), strerror(errno));
                         assert(0);
                         break;
                     }
@@ -385,7 +384,7 @@ StatusCode Block::Append(int32_t seq, const char* buf, int64_t len) {
     MutexLock lock(&mu_, "BlockAppend", 1000);
     if (finished_ || deleted_) {
         LOG(INFO, "[Append] block #%ld closed, do not append to blockbuf_. finished_=%d, deleted_=%d",
-            meta_.block_id, finished_, deleted_);
+            meta_.block_id(), finished_, deleted_);
         return kBlockClosed;
     }
     if (blockbuf_ == NULL) {
@@ -414,7 +413,7 @@ StatusCode Block::Append(int32_t seq, const char* buf, int64_t len) {
         memcpy(blockbuf_ + bufdatalen_, buf, ap_len);
         bufdatalen_ += ap_len;
     }
-    meta_.block_size += len;
+    meta_.set_block_size(meta_.block_size() + len);
     g_data_size.Add(len);
     last_seq_ = seq;
     return kOK;

--- a/src/chunkserver/data_block.cc
+++ b/src/chunkserver/data_block.cc
@@ -113,7 +113,7 @@ Block::~Block() {
         }
         delete recv_window_;
     }
-    LOG(INFO, "Block #%ld destruct", meta_.block_id());
+    LOG(INFO, "Block #%ld deconstruct", meta_.block_id());
     g_blocks.Dec();
     g_data_size.Sub(meta_.block_size());
 }

--- a/src/chunkserver/data_block.h
+++ b/src/chunkserver/data_block.h
@@ -15,6 +15,8 @@
 #include <common/sliding_window.h>
 #include "proto/status_code.pb.h"
 
+#include "proto/block.pb.h"
+
 namespace baidu {
 namespace bfs {
 
@@ -29,24 +31,13 @@ struct Buffer {
       : data_(o.data_), len_(o.len_) {}
 };
 
-/// Meta of a data block
-struct BlockMeta {
-    int64_t block_id;
-    int64_t block_size;
-    int64_t checksum;
-    int64_t version;
-    BlockMeta()
-      : block_id(0), block_size(0), checksum(0), version(-1) {
-    }
-};
 
 class FileCache;
 
 /// Data block
 class Block {
 public:
-    Block(const BlockMeta& meta, const std::string& store_path, ThreadPool* thread_pool,
-          FileCache* file_cache);
+    Block(const BlockMeta& meta, ThreadPool* thread_pool, FileCache* file_cache);
     ~Block();
     static std::string BuildFilePath(int64_t block_id);
     /// Getter

--- a/src/proto/block.proto
+++ b/src/proto/block.proto
@@ -3,7 +3,7 @@ package baidu.bfs;
 
 message BlockMeta {
     optional int64 block_id = 1;
-    optional int64 block_size = 2 [default = 0];
+    optional int64 block_size = 2;
     optional int64 checksum = 3;
     optional int64 version = 4 [default = -1];
     optional string store_path = 5;

--- a/src/proto/block.proto
+++ b/src/proto/block.proto
@@ -1,0 +1,10 @@
+
+package baidu.bfs;
+
+message BlockMeta {
+    optional int64 block_id = 1;
+    optional int64 block_size = 2 [default = 0];
+    optional int64 checksum = 3;
+    optional int64 version = 4 [default = -1];
+    optional string store_path = 5;
+}


### PR DESCRIPTION
#345
对每个block存储其路径前缀，如/data/0000/000000这个block，在其元信息中存储/data，其余部分仍按原来的取模计算出来
之所以这样，是因为：
1）路径前缀一般不会太大，按每个block10个字节来算，不算压缩，1kw个block也仅占100MB空间
2）如果不存前缀，而在cs中统一存储上一次的路径配置，每次启动时跟当前作比较，则需要大量的move操作，比如第一次配置了5块盘，然后重启，变为4块盘，虽然可以把之前4块盘中的block找到，但是部分磁盘中的block则需要move到其它盘， 类似重哈希，感觉代价略大