### PR TITLE
Remove useless code & add log

### DIFF
--- a/src/nameserver/block_mapping.cc
+++ b/src/nameserver/block_mapping.cc
@@ -605,14 +605,14 @@ bool BlockMapping::RemoveFromRecoverCheckList(int32_t cs_id, int64_t block_id) {
     std::set<int64_t>::iterator it = lo_recover_check_[cs_id].find(block_id);
     if (it != lo_recover_check_[cs_id].end()){
         lo_recover_check_[cs_id].erase(it);
-        //LOG(DEBUG, "Remove #%ld from lo_recover_check", block_id);
+        LOG(DEBUG, "Remove #%ld from lo_recover_check", block_id);
         if (lo_recover_check_[cs_id].empty()) {
             lo_recover_check_.erase(cs_id);
         }
     } else {
         it = hi_recover_check_[cs_id].find(block_id);
         if (it != hi_recover_check_[cs_id].end()) {
-            //LOG(DEBUG, "Remove #%ld from hi_recover_check", block_id);
+            LOG(DEBUG, "Remove #%ld from hi_recover_check", block_id);
             hi_recover_check_[cs_id].erase(it);
             if (hi_recover_check_[cs_id].empty()) {
                 hi_recover_check_.erase(cs_id);
@@ -632,7 +632,6 @@ void BlockMapping::ProcessRecoveredBlock(int32_t cs_id, int64_t block_id) {
         return;
     }
     if (ret) {
-        block->incomplete_replica.erase(cs_id);
         SetState(block, kNotInRecover);
     } else {
         LOG(WARNING, "RemoveFromRecoverCheckList fail #%ld C%d %s",


### PR DESCRIPTION
`block->incomplete_replica.erase(cs_id); `应该是pull时的遗留产物了