### PR TITLE
Split chunkserver_manager lock

### DIFF
--- a/src/nameserver/chunkserver_manager.cc
+++ b/src/nameserver/chunkserver_manager.cc
@@ -49,6 +49,7 @@ void ChunkServerManager::CleanChunkServer(ChunkServerInfo* cs, const std::string
     std::map<int32_t, ChunkServerBlockMap*>::iterator it = chunkserver_block_map_.find(id);
     assert(it != chunkserver_block_map_.end());
     ChunkServerBlockMap* cs_block_map = it->second;
+    MutexLock cs_block_map_lock(cs_block_map->mu);
     std::swap(blocks, cs_block_map->blocks);
     LOG(INFO, "Remove ChunkServer C%d %s %s, cs_num=%d",
             cs->id(), cs->address().c_str(), reason.c_str(), chunkserver_num_);

--- a/src/nameserver/chunkserver_manager.cc
+++ b/src/nameserver/chunkserver_manager.cc
@@ -46,12 +46,10 @@ void ChunkServerManager::CleanChunkServer(ChunkServerInfo* cs, const std::string
     int32_t id = cs->id();
     MutexLock lock(&mu_, "CleanChunkServer", 10);
     chunkserver_num_--;
-    std::map<int32_t, std::pair<Mutex*, std::set<int64_t> > >::iterator it =
-        chunkserver_block_map_.find(id);
+    std::map<int32_t, ChunkServerBlockMap*>::iterator it = chunkserver_block_map_.find(id);
     assert(it != chunkserver_block_map_.end());
-    std::swap(blocks, (it->second).second);
-    delete (it->second).first;
-    chunkserver_block_map_.erase(id);
+    ChunkServerBlockMap* cs_block_map = it->second;
+    std::swap(blocks, cs_block_map->blocks);
     LOG(INFO, "Remove ChunkServer C%d %s %s, cs_num=%d",
             cs->id(), cs->address().c_str(), reason.c_str(), chunkserver_num_);
     cs->set_status(kCsCleaning);
@@ -467,8 +465,8 @@ int32_t ChunkServerManager::AddChunkServer(const std::string& address,
     heartbeat_list_[now_time].insert(info);
     info->set_last_heartbeat(now_time);
     ++chunkserver_num_;
-    Mutex* mu = new Mutex;
-    chunkserver_block_map_.insert(std::make_pair(id, std::make_pair(mu, std::set<int64_t>())));
+    ChunkServerBlockMap* cs_block_map = new ChunkServerBlockMap;
+    chunkserver_block_map_.insert(std::make_pair(id, cs_block_map));
     return id;
 }
 
@@ -491,33 +489,27 @@ int32_t ChunkServerManager::GetChunkServerId(const std::string& addr) {
 }
 
 void ChunkServerManager::AddBlock(int32_t id, int64_t block_id) {
-    Mutex* mu = NULL;
-    std::set<int64_t>* block_set = NULL;
+    ChunkServerBlockMap* cs_block_map = NULL;
     {
         MutexLock lock(&mu_);
-        std::map<int32_t, std::pair<Mutex*, std::set<int64_t> > >::iterator it
-            = chunkserver_block_map_.find(id);
+        std::map<int32_t, ChunkServerBlockMap*>::iterator it = chunkserver_block_map_.find(id);
         assert(it != chunkserver_block_map_.end());
-        mu = (it->second).first;
-        block_set = &((it->second).second);
+        cs_block_map = it->second;
     }
-    MutexLock lock(mu);
-    block_set->insert(block_id);
+    MutexLock lock(cs_block_map->mu);
+    cs_block_map->blocks.insert(block_id);
 }
 
 void ChunkServerManager::RemoveBlock(int32_t id, int64_t block_id) {
-    Mutex* mu = NULL;
-    std::set<int64_t>* block_set = NULL;
-    std::map<int32_t, std::pair<Mutex*, std::set<int64_t> > >::iterator it;
+    ChunkServerBlockMap* cs_block_map = NULL;
     {
         MutexLock lock(&mu_, "RemoveBlock", 10);
-        it = chunkserver_block_map_.find(id);
+        std::map<int32_t, ChunkServerBlockMap*>::iterator it = chunkserver_block_map_.find(id);
         assert(it != chunkserver_block_map_.end());
-        mu = (it->second).first;
-        block_set = &((it->second).second);
+        cs_block_map = it->second;
     }
-    MutexLock lock(mu);
-    block_set->erase(block_id);
+    MutexLock lock(cs_block_map->mu);
+    cs_block_map->blocks.erase(block_id);
 }
 
 void ChunkServerManager::PickRecoverBlocks(int cs_id,

--- a/src/nameserver/chunkserver_manager.h
+++ b/src/nameserver/chunkserver_manager.h
@@ -49,24 +49,6 @@ public:
     StatusCode ShutdownChunkServer(const::google::protobuf::RepeatedPtrField<std::string>& chunkserver_address);
     bool GetShutdownChunkServerStat();
 private:
-    double GetChunkServerLoad(ChunkServerInfo* cs);
-    void DeadCheck();
-    void RandomSelect(std::vector<std::pair<double, ChunkServerInfo*> >* loads, int num);
-    bool GetChunkServerPtr(int32_t cs_id, ChunkServerInfo** cs);
-    void LogStats();
-    int SelectChunkServerByZone(int num,
-        const std::vector<std::pair<double, ChunkServerInfo*> >& loads,
-        std::vector<std::pair<int32_t,std::string> >* chains);
-    void MarkChunkServerReadonly(const std::string& chunkserver_address);
-private:
-    ThreadPool* thread_pool_;
-    BlockMappingManager* block_mapping_manager_;
-    Mutex mu_;      /// chunkserver_s list mutext;
-    Stats stats_;
-    typedef std::map<int32_t, ChunkServerInfo*> ServerMap;
-    ServerMap chunkservers_;
-    std::map<std::string, int32_t> address_map_;
-    std::map<int32_t, std::set<ChunkServerInfo*> > heartbeat_list_;
     struct ChunkServerBlockMap {
         Mutex* mu;
         std::set<int64_t> blocks;
@@ -77,6 +59,25 @@ private:
             delete mu;
         }
     };
+    double GetChunkServerLoad(ChunkServerInfo* cs);
+    void DeadCheck();
+    void RandomSelect(std::vector<std::pair<double, ChunkServerInfo*> >* loads, int num);
+    bool GetChunkServerPtr(int32_t cs_id, ChunkServerInfo** cs);
+    void LogStats();
+    int SelectChunkServerByZone(int num,
+        const std::vector<std::pair<double, ChunkServerInfo*> >& loads,
+        std::vector<std::pair<int32_t,std::string> >* chains);
+    void MarkChunkServerReadonly(const std::string& chunkserver_address);
+    bool GetChunkServerBlockMapPtr(int32_t cs_id, ChunkServerBlockMap** cs_block_map);
+private:
+    ThreadPool* thread_pool_;
+    BlockMappingManager* block_mapping_manager_;
+    Mutex mu_;      /// chunkserver_s list mutext;
+    Stats stats_;
+    typedef std::map<int32_t, ChunkServerInfo*> ServerMap;
+    ServerMap chunkservers_;
+    std::map<std::string, int32_t> address_map_;
+    std::map<int32_t, std::set<ChunkServerInfo*> > heartbeat_list_;
     std::map<int32_t, ChunkServerBlockMap*> chunkserver_block_map_;
     int32_t chunkserver_num_;
     int32_t next_chunkserver_id_;

--- a/src/nameserver/chunkserver_manager.h
+++ b/src/nameserver/chunkserver_manager.h
@@ -67,7 +67,7 @@ private:
     ServerMap chunkservers_;
     std::map<std::string, int32_t> address_map_;
     std::map<int32_t, std::set<ChunkServerInfo*> > heartbeat_list_;
-    std::map<int32_t, std::set<int64_t> > chunkserver_block_map_;
+    std::map<int32_t, std::pair<Mutex*, std::set<int64_t> > > chunkserver_block_map_;
     int32_t chunkserver_num_;
     int32_t next_chunkserver_id_;
 

--- a/src/nameserver/chunkserver_manager.h
+++ b/src/nameserver/chunkserver_manager.h
@@ -67,7 +67,17 @@ private:
     ServerMap chunkservers_;
     std::map<std::string, int32_t> address_map_;
     std::map<int32_t, std::set<ChunkServerInfo*> > heartbeat_list_;
-    std::map<int32_t, std::pair<Mutex*, std::set<int64_t> > > chunkserver_block_map_;
+    struct ChunkServerBlockMap {
+        Mutex* mu;
+        std::set<int64_t> blocks;
+        ChunkServerBlockMap() {
+            mu = new Mutex;
+        }
+        ~ChunkServerBlockMap() {
+            delete mu;
+        }
+    };
+    std::map<int32_t, ChunkServerBlockMap*> chunkserver_block_map_;
     int32_t chunkserver_num_;
     int32_t next_chunkserver_id_;
 


### PR DESCRIPTION
感觉这样并不安全。
CleanChunkServer时，会把cs对应的锁删掉，万一这时有人持有这个锁，就悲剧了。
也要搞个shared_ptr了么。。。