### PR TITLE
du支持通配符

### DIFF
--- a/src/client/bfs_client.cc
+++ b/src/client/bfs_client.cc
@@ -6,6 +6,7 @@
 
 #include <gflags/gflags.h>
 
+#include <assert.h>
 #include <fcntl.h>
 #include <stdio.h>
 #include <string.h>
@@ -15,8 +16,9 @@
 #include <sys/stat.h>
 #include <map>
 
-#include <common/util.h>
 #include <common/timer.h>
+#include <common/string_util.h>
+#include <common/util.h>
 #include "sdk/bfs.h"
 
 DECLARE_string(flagfile);
@@ -254,6 +256,8 @@ int64_t BfsDuV2(baidu::bfs::FS* fs, const std::string& path) {
         fprintf(stderr, "Compute Disk Usage fail: %s\n", path.c_str());
         return -1;
     }
+    printf("%-9s\t%s\n",
+           baidu::common::HumanReadableString(du_size).c_str(), path.c_str());
     return du_size;
 }
 
@@ -262,11 +266,33 @@ int BfsDu(baidu::bfs::FS* fs, int argc, char* argv[]) {
         print_usage();
         return 1;
     }
-    int64_t du = 0;
-    if ((du = BfsDuV2(fs, argv[0])) < 0) {
-        du = BfsDuRecursive(fs, argv[0]);
+    std::string path = argv[0];
+    assert(path.size() > 0);
+    if (path[path.size() - 1] != '*') {
+        return BfsDuV2(fs, path);
     }
-    printf("Total:\t%ld\n", du);
+    path.resize(path.size() - 1);
+    std::string ppath = path.substr(0, path.rfind('/') + 1);
+    std::string prefix = path.substr(ppath.size());
+    // printf("ppath= %s\n", ppath.c_str());
+    // printf("prefix= %s\n", prefix.c_str());
+    // Wildcard
+    int64_t total_size = 0;
+    baidu::bfs::BfsFileInfo* files = NULL;
+    int num = 0;
+    int ret = fs->ListDirectory(ppath.c_str(), &files, &num);
+    if (ret != 0) {
+        fprintf(stderr, "Path not found: %s\n", ppath.c_str());
+        return -1;
+    }
+    for (int i = 0; i < num; i++) {
+        std::string name(files[i].name);
+        if (name.find(prefix) != std::string::npos) {
+            int64_t sz = BfsDuV2(fs, ppath + name);
+            if (sz > 0) total_size += sz;
+        }
+    }
+    printf("Total: %s\n", baidu::common::HumanReadableString(total_size).c_str());
     return 0;
 }
 

--- a/src/client/bfs_client.cc
+++ b/src/client/bfs_client.cc
@@ -271,12 +271,11 @@ int BfsDu(baidu::bfs::FS* fs, int argc, char* argv[]) {
     if (path[path.size() - 1] != '*') {
         return BfsDuV2(fs, path);
     }
+
+    // Wildcard
     path.resize(path.size() - 1);
     std::string ppath = path.substr(0, path.rfind('/') + 1);
     std::string prefix = path.substr(ppath.size());
-    // printf("ppath= %s\n", ppath.c_str());
-    // printf("prefix= %s\n", prefix.c_str());
-    // Wildcard
     int64_t total_size = 0;
     baidu::bfs::BfsFileInfo* files = NULL;
     int num = 0;


### PR DESCRIPTION
为了支持
bfs_client du /webdb/tablet*
bfs_client du /*
类似的操作，当前有个问题，shell会对*进行转义替换，所以我们只能bfs_client du /\*